### PR TITLE
[AW-51] GET 고민 리스트

### DIFF
--- a/controllers/counsels.controller.js
+++ b/controllers/counsels.controller.js
@@ -26,11 +26,11 @@ exports.createCounsel = async (req, res, next) => {
 
 exports.getCounselList = async (req, res, next) => {
   try {
-    const story = await Counsel.find().populate("counselee").lean();
+    const stories = await Counsel.find().populate("counselee").lean();
 
-    res.status(201).json({
+    res.status(200).json({
       result: "success",
-      story: story,
+      �data: stories,
     });
   } catch (err) {
     next(createError(err));

--- a/controllers/counsels.controller.js
+++ b/controllers/counsels.controller.js
@@ -28,16 +28,12 @@ exports.getCounselList = async (req, res, next) => {
   try {
     const story = await Counsel.find().populate("counselee").lean();
 
-    if (!story) {
-      return next(createError(400));
-    } else {
-      res.status(201).json({
-        result: "success",
-        story: story,
-      });
-    }
+    res.status(201).json({
+      result: "success",
+      story: story,
+    });
   } catch (err) {
-    next(createError(500, err));
+    next(createError(err));
   }
 };
 

--- a/controllers/counsels.controller.js
+++ b/controllers/counsels.controller.js
@@ -24,6 +24,23 @@ exports.createCounsel = async (req, res, next) => {
   }
 };
 
+exports.getCounselList = async (req, res, next) => {
+  try {
+    const story = await Counsel.find().populate("counselee").lean();
+
+    if (!story) {
+      return next(createError(400));
+    } else {
+      res.status(201).json({
+        result: "success",
+        story: story,
+      });
+    }
+  } catch (err) {
+    next(createError(500, err));
+  }
+};
+
 exports.getCounsel = async (req, res, next) => {
   try {
     const { counsel_id } = req.params;

--- a/routes/counsels.js
+++ b/routes/counsels.js
@@ -4,10 +4,12 @@ const router = express.Router();
 const {
   createCounsel,
   getCounsel,
+  getCounselList,
 } = require("../controllers/counsels.controller");
 const { checkObjectId } = require("../middlewares/validateObjectId");
 
 router.post("/", createCounsel);
+router.get("/", getCounselList);
 router.get("/:counsel_id", checkObjectId, getCounsel);
 
 module.exports = router;


### PR DESCRIPTION
# [AW-51] GET 고민 리스트

## 지라 칸반 링크
- [GET 고민 리스트](https://merkyuri.atlassian.net/browse/AW-51?atlOrigin=eyJpIjoiZmRmMzUwMTFkNTdmNDEwZTlkNzA3Nzg0N2M0MWY5MzQiLCJwIjoiaiJ9)
  ​

## 카드에서 구현 혹은 해결하려는 내용
- ​고민담벼락 페이지의 모든 사연 리스트를 불러온다.

## 테스트 방법
- Postman에서 `http://${URL}/api/counsels`로 GET 요청.

## 기타 사항
- 현재 mock data로 관리중이라서 이와 같이 구현해주었는데, 수정이 필요하거나 에러 처리 필요한 부분이 있다면 생각해보겠습니다. 생각나는게 있으시다면 코멘트 부탁드립니다!

[AW-51]: https://merkyuri.atlassian.net/browse/AW-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ