### PR TITLE
[AW-103 ]update Counsel (사연수락한 카운슬러 고민담벼락에 추가하기)

### DIFF
--- a/constants/index.js
+++ b/constants/index.js
@@ -4,8 +4,9 @@ const RESPONSE = {
 };
 
 const MESSAGE = {
-  BADREQUEST: "유효하지 않은 접근입니다.",
+  BAD_REQUEST: "유효하지 않은 접근입니다.",
   UNAUTHORIZED: "유효하지 않은 권한입니다.",
+  INVAILD_OBJECT_ID: "유효하지 않은 object id입니다.",
 };
 
 module.exports = { RESPONSE, MESSAGE };

--- a/controllers/counsels.controller.js
+++ b/controllers/counsels.controller.js
@@ -1,3 +1,4 @@
+const mongoose = require("mongoose");
 const createError = require("http-errors");
 
 const Counsel = require("../models/Counsel");
@@ -30,7 +31,7 @@ exports.getCounselList = async (req, res, next) => {
 
     res.status(200).json({
       result: "success",
-      �data: stories,
+      data: stories,
     });
   } catch (err) {
     next(createError(err));
@@ -51,11 +52,54 @@ exports.getCounsel = async (req, res, next) => {
       return;
     }
 
-    res.status(201).json({
+    res.status(200).json({
       result: RESPONSE.SUCCESS,
       data: counsel,
     });
   } catch (err) {
+    next(createError(err));
+  }
+};
+
+exports.updateCounsel = async (req, res, next) => {
+  try {
+    const { counsel_id } = req.params;
+    const { userId } = req.body;
+
+    const { counselors } = await Counsel.findById(counsel_id)
+      .select("counselors")
+      .lean();
+
+    const isContain = counselors.some(
+      (counselorId) => counselorId.toString() === userId.toString()
+    );
+
+    if (isContain) {
+      next(createError(400, "사연 수락은 한번만 할 수 있습니다."), {
+        result: RESPONSE.FAIL,
+      });
+      return;
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(userId)) {
+      next(createError(400, MESSAGE.INVAILD_OBJECT_ID));
+      return;
+    }
+
+    await Counsel.findByIdAndUpdate(counsel_id, {
+      $push: { counselors: userId },
+    });
+
+    res.status(201).json({
+      result: RESPONSE.SUCCESS,
+      data: null,
+    });
+  } catch (err) {
+    if (err.name === "TypeError") {
+      next(createError.BadRequest(MESSAGE.BADREQUEST));
+      return;
+    }
+
     next(createError(err));
   }
 };

--- a/middlewares/validateObjectId.js
+++ b/middlewares/validateObjectId.js
@@ -1,6 +1,8 @@
 const mongoose = require("mongoose");
 const createError = require("http-errors");
 
+const { MESSAGE } = require("../constants");
+
 exports.checkObjectId = function (req, res, next) {
   const [paramId] = Object.values(req.params);
 
@@ -9,5 +11,5 @@ exports.checkObjectId = function (req, res, next) {
     return;
   }
 
-  next(createError(400, "유효하지 않은 object id입니다."));
+  next(createError(400, MESSAGE.INVAILD_OBJECT_ID));
 };

--- a/mockData/new_counsel_data.json
+++ b/mockData/new_counsel_data.json
@@ -1,5 +1,5 @@
 {
-  "counselee": "6200ea84cbd9a856da8ea7f1",
+  "counselee": "6201cb5daf452eda2c0c89b2",
   "title": "leggo",
   "content": "lets go ~!!!!!!",
   "tag": ["fire", "fighting", "haha"],

--- a/mockData/user_data.json
+++ b/mockData/user_data.json
@@ -2,7 +2,7 @@
   {
     "email": "hi@gmail.com",
     "nickname": "헝그리맨",
-    "imageURL": "1234",
+    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
@@ -15,7 +15,7 @@
   {
     "email": "iam20@gmail.com",
     "nickname": "턴즈",
-    "imageURL": "1234",
+    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
@@ -28,7 +28,7 @@
   {
     "email": "proudman@gmail.com",
     "nickname": "프라우드먼",
-    "imageURL": "1234",
+    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
@@ -41,7 +41,7 @@
   {
     "email": "camo@gmail.com",
     "nickname": "cashmoney",
-    "imageURL": "1234",
+    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
@@ -54,7 +54,7 @@
   {
     "email": "cl@gmail.com",
     "nickname": "닥터페퍼",
-    "imageURL": "1234",
+    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
@@ -67,7 +67,7 @@
   {
     "email": "noze@gmail.com",
     "nickname": "노제",
-    "imageURL": "1234",
+    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
@@ -80,7 +80,7 @@
   {
     "email": "g-dragon@gmail.com",
     "nickname": "권지용",
-    "imageURL": "1234",
+    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
@@ -93,7 +93,7 @@
   {
     "email": "ken@gmail.com",
     "nickname": "허켄",
-    "imageURL": "1234",
+    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
@@ -106,7 +106,7 @@
   {
     "email": "merkyuri@gmail.com",
     "nickname": "머큐리규리",
-    "imageURL": "1234",
+    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
@@ -119,7 +119,7 @@
   {
     "email": "jaypark@gmail.com",
     "nickname": "박재범",
-    "imageURL": "1234",
+    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
@@ -132,7 +132,7 @@
   {
     "email": "loco@gmail.com",
     "nickname": "로꼬",
-    "imageURL": "1234",
+    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",

--- a/routes/counsels.js
+++ b/routes/counsels.js
@@ -5,11 +5,13 @@ const {
   createCounsel,
   getCounsel,
   getCounselList,
+  updateCounsel,
 } = require("../controllers/counsels.controller");
 const { checkObjectId } = require("../middlewares/validateObjectId");
 
 router.post("/", createCounsel);
 router.get("/", getCounselList);
+router.post("/:counsel_id/counselors", checkObjectId, updateCounsel);
 router.get("/:counsel_id", checkObjectId, getCounsel);
 
 module.exports = router;


### PR DESCRIPTION
# [{AW-103}] {사연수락한 카운슬러 고민담벼락에 추가하기}

## 지라 칸반 링크

- [POST 사연수락 카운슬러 리스트에 추가하기](https://merkyuri.atlassian.net/browse/AW-103?atlOrigin=eyJpIjoiODZhODYxNDhjOThmNGNmNDgzMzZiNTc1ODBkYTY0MTciLCJwIjoiaiJ9)
  ​

## 카드에서 구현 혹은 해결하려는 내용
- ​고민담벼락에서 수락하기를 누른 카운슬러를 해당 고민담벼락의 counselors 배열에 추가시키는 작업.
- counselors 배열에 해당 카운슬러가 있는지 체크 후 없다면 push후 성공응답을, 있다면 에러응답을 한다.

## 테스트 방법

-
-

## 기타 사항
-
