### PR TITLE
[AW-71] 고민담벼락 페이지네이션 적용, 검색한 태그 가져오기

### DIFF
--- a/controllers/counsels.controller.js
+++ b/controllers/counsels.controller.js
@@ -27,11 +27,9 @@ exports.createCounsel = async (req, res, next) => {
 
 exports.getCounselList = async (req, res, next) => {
   try {
-    const stories = await Counsel.find().populate("counselee").lean();
-
     res.status(200).json({
-      result: "success",
-      data: stories,
+      result: RESPONSE.SUCCESS,
+      data: req.pagination,
     });
   } catch (err) {
     next(createError(err));

--- a/middlewares/pagination.js
+++ b/middlewares/pagination.js
@@ -1,0 +1,46 @@
+const createError = require("http-errors");
+
+const Counsel = require("../models/Counsel");
+
+exports.pagination = async (req, res, next) => {
+  try {
+    const { page = 1, size = 4, tag, counselor } = req.query;
+    const options = {};
+
+    if (tag) {
+      options.tag = { $elemMatch: { $eq: tag } };
+    }
+
+    if (counselor) {
+      options.counselor = { $exists: false };
+    }
+
+    const totalCounsel = await Counsel.countDocuments();
+    const pageCounsels = await Counsel.find(options)
+      .sort({ createdAt: -1 })
+      .limit(parseInt(size))
+      .skip((page - 1) * parseInt(size))
+      .populate("counselee")
+      .lean();
+
+    const data = {
+      hasPrevPage: true,
+      hasNextPage: true,
+      pageCounsels,
+    };
+
+    if (parseInt(page) === 1) {
+      data.hasPrevPage = false;
+    }
+
+    if (parseInt(page) * size >= totalCounsel) {
+      data.hasNextPage = false;
+    }
+
+    req.pagination = data;
+
+    next();
+  } catch (err) {
+    next(createError(err));
+  }
+};

--- a/routes/counsels.js
+++ b/routes/counsels.js
@@ -1,16 +1,17 @@
 const express = require("express");
 const router = express.Router();
 
+const { checkObjectId } = require("../middlewares/validateObjectId");
+const { pagination } = require("../middlewares/pagination");
 const {
   createCounsel,
   getCounsel,
   getCounselList,
   updateCounsel,
 } = require("../controllers/counsels.controller");
-const { checkObjectId } = require("../middlewares/validateObjectId");
 
 router.post("/", createCounsel);
-router.get("/", getCounselList);
+router.get("/", pagination, getCounselList);
 router.post("/:counsel_id/counselors", checkObjectId, updateCounsel);
 router.get("/:counsel_id", checkObjectId, getCounsel);
 


### PR DESCRIPTION
# [AW-71] {고민담벼락 페이지네이션 적용, 검색한 태그 가져오기}

## 지라 칸반 링크

- [[Backend] GET 검색한 해시태그와 일치하는 고민](https://merkyuri.atlassian.net/browse/AW-71?atlOrigin=eyJpIjoiY2VhNmY1NjNmYjk1NDc4ODlhYzM2YjBmNzdjNGY1YjEiLCJwIjoiaiJ9)
  ​

## 카드에서 구현 혹은 해결하려는 내용
- ​페이지네이션이 필요한 페이지에 사용할 수 있는 미들웨어 만듬.
- 검색한 태그에 해당되는 다큐먼트만 data에 넣음
- 카운슬러(확정된) 없는 다큐먼트만 data에 넣음

## 테스트 방법

-
-

## 기타 사항

- 마이페이지에서도 사용할 수 있게 하고 싶은데 그런 부분에서는 좀 재사용성이 떨어질 수 있다고 생각이 들어요ㅜㅜ 어떻게 하면 재사용하기 좋을지 같이 이야기해보면 좋을 것 같아요


[AW-71]: https://merkyuri.atlassian.net/browse/AW-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ