### PR TITLE
[AW-58] [Backend] PATCH 카운슬러 상담 예약 (Counsel)

### DIFF
--- a/constants/index.js
+++ b/constants/index.js
@@ -7,7 +7,7 @@ const MESSAGE = {
   BAD_REQUEST: "유효하지 않은 접근입니다.",
   UNAUTHORIZED: "유효하지 않은 권한입니다.",
   INVALID_OBJECT_ID: "유효하지 않은 object id입니다.",
-  UNAVAILABLE_DATE: "선택한 날짜는 예약 할 수 없습니다.",
+  UNAVAILABLE_DATE: "선택하신 날짜는 예약 할 수 없습니다.",
   DUPLICATE_REQUEST: "사연 수락은 한번만 할 수 있습니다.",
 };
 

--- a/constants/index.js
+++ b/constants/index.js
@@ -6,7 +6,9 @@ const RESPONSE = {
 const MESSAGE = {
   BAD_REQUEST: "유효하지 않은 접근입니다.",
   UNAUTHORIZED: "유효하지 않은 권한입니다.",
-  INVAILD_OBJECT_ID: "유효하지 않은 object id입니다.",
+  INVALID_OBJECT_ID: "유효하지 않은 object id입니다.",
+  UNAVAILABLE_DATE: "선택한 날짜는 예약 할 수 없습니다.",
+  DUPLICATE_REQUEST: "사연 수락은 한번만 할 수 있습니다.",
 };
 
 module.exports = { RESPONSE, MESSAGE };

--- a/controllers/counsels.controller.js
+++ b/controllers/counsels.controller.js
@@ -157,7 +157,18 @@ exports.getCounsel = async (req, res, next) => {
   }
 };
 
-exports.updateCounsel = async (req, res, next) => {
+// exports.updateCounsel = async (req, res, next) => {
+//   try {
+//     const { counsel_id } = req.params;
+//     const { counselor, startDate, endDate } = req.body;
+
+//     const reservedCounsel = await Counsel.findByIdAndUpdate()
+//   } catch (err) {
+//     next(createError(err));
+//   }
+// };
+
+exports.updateCounselors = async (req, res, next) => {
   try {
     const { counsel_id } = req.params;
     const { userId } = req.body;

--- a/controllers/users.controller.js
+++ b/controllers/users.controller.js
@@ -10,7 +10,7 @@ exports.getCounselor = async (req, res, next) => {
     const counselor = await User.findById(user_id).lean();
 
     if (!counselor) {
-      next(createError.BadRequest(MESSAGE.BADREQUEST));
+      next(createError.BadRequest(MESSAGE.BAD_REQUEST));
       return;
     }
 

--- a/middlewares/validateObjectId.js
+++ b/middlewares/validateObjectId.js
@@ -11,5 +11,5 @@ exports.checkObjectId = function (req, res, next) {
     return;
   }
 
-  next(createError(400, MESSAGE.INVAILD_OBJECT_ID));
+  next(createError(400, MESSAGE.INVALID_OBJECT_ID));
 };

--- a/mockData/new_counsel_data.json
+++ b/mockData/new_counsel_data.json
@@ -1,12 +1,11 @@
 {
   "counselee": "6201cb5daf452eda2c0c89b2",
-  "counselor": "내가 상담사",
-  "title": "leggo",
+  "counselor": "6201468fd480bfaf26bcc73f",
+  "title": "바다로 간 장금이",
   "content": "lets go ~!!!!!!",
-  "tag": ["fire", "fighting", "haha"],
+  "tag": ["fire", "fighting", "ha ha"],
   "createdAt": "2021-01-23T19:30:00.000+00:00",
-  "counselors": "6201468fd480bfaf26bcc73d",
+  "counselors": ["6201468fd480bfaf26bcc73d", "6201468fd480bfaf26bcc73c"],
   "startDate": "2021-02-11T19:30:00.000+00:00",
   "endDate": "2021-02-11T20:00:00.000+00:00"
 }
-

--- a/mockData/new_counsel_data.json
+++ b/mockData/new_counsel_data.json
@@ -1,8 +1,12 @@
 {
   "counselee": "6201cb5daf452eda2c0c89b2",
+  "counselor": "내가 상담사",
   "title": "leggo",
   "content": "lets go ~!!!!!!",
   "tag": ["fire", "fighting", "haha"],
-  "createdAt": "2021-01-23T19:30:00.000+00:00"
+  "createdAt": "2021-01-23T19:30:00.000+00:00",
+  "counselors": "6201468fd480bfaf26bcc73d",
+  "startDate": "2021-02-11T19:30:00.000+00:00",
+  "endDate": "2021-02-11T20:00:00.000+00:00"
 }
 

--- a/models/User.js
+++ b/models/User.js
@@ -40,11 +40,14 @@ const UserSchema = new mongoose.Schema({
         index: true,
       },
     ],
-    validDate: [
+    availableDate: [
       {
-        day: String,
-        start: String,
-        end: String,
+        type: { type: String },
+        day: Number,
+        startHour: Number,
+        endHour: Number,
+        startTime: Date,
+        endTime: Date,
       },
     ],
   },

--- a/routes/counsels.js
+++ b/routes/counsels.js
@@ -7,14 +7,16 @@ const {
   createCounsel,
   getCounselList,
   getReservedCounselList,
-  updateCounsel,
   getCounsel,
+  updateCounsel,
+  updateCounselors,
 } = require("../controllers/counsels.controller");
 
 router.post("/", verifyToken, createCounsel);
 router.get("/", getCounselList);
 router.get("/reserved", getReservedCounselList);
-router.post("/:counsel_id/counselors", checkObjectId, updateCounsel);
 router.get("/:counsel_id", checkObjectId, getCounsel);
+router.post("/:counsel_id/counselors", checkObjectId, updateCounsel);
+router.post("/:counsel_id/counselors", checkObjectId, updateCounselors);
 
 module.exports = router;


### PR DESCRIPTION
# [AW-58] [Backend] PATCH 카운슬러 상담 예약 (Counsel)

## 지라 칸반 링크
- [[Backend] PATCH 카운슬러 상담 예약 (Counsel)](https://merkyuri.atlassian.net/browse/AW-58?atlOrigin=eyJpIjoiOTI2MjZiOGY4ZmE2NDhlMWI0YzE5NjFjOTBiOGEzNTUiLCJwIjoiaiJ9)
  ​
## 카드에서 구현 혹은 해결하려는 내용
- ​상담 요청 한 카운슬러의 세부사항에서 상담 예약을 했을 때 예약 정보를 기존 데이터에 새로 업데이트 시켜준다.

## 테스트 방법
- postman

## 기타 사항
- 구현하면서 가장 큰 테스크가 카운슬러의 아이디를 저장해주는거였는데요, objectId는 다른 필드처럼 바로 새로운 정보로 업데이트 시켜줄 수 없기 때문에 삭제 후 다시 필드를 저장하는 방법으로 구현했습니다. 처음에 counsel 데이터가 생성될 때 빈 값으로 넣어줘야 하나 그 부분도 고민했는데 다른 코드를 수정하는 번거로움을 줄이고자 update + insert 기능을 가진 `{upsert: true},` option으로 해결해주었습니다. 

- 에러 핸들링은 최대한 생각해봤는데 이미 몇번 거치고 들어오는 경로이기도 하고 날짜는 클라이언트 쪽에서 `availableDate`에 대한 정보만 잘 보내주면 괜찮지 않을까 하고 생각했는데 다른 의견 있으시다면 코멘트 부탁드립니다! 

[AW-58]: https://merkyuri.atlassian.net/browse/AW-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ