### PR TITLE
AW-120 [Backend] POST 카운슬러 스케줄 변경 요청

### DIFF
--- a/controllers/counsels.controller.js
+++ b/controllers/counsels.controller.js
@@ -42,7 +42,7 @@ exports.getCounselList = async (req, res, next) => {
     }
 
     const totalCounsel = await Counsel.countDocuments();
-    const reservedCounsels = await Counsel.find(options)
+    const pageCounsels = await Counsel.find(options)
       .sort(sortBy)
       .limit(parseInt(limit))
       .skip((page - 1) * parseInt(limit))
@@ -52,7 +52,7 @@ exports.getCounselList = async (req, res, next) => {
     const data = {
       hasPrevPage: true,
       hasNextPage: true,
-      reservedCounsels,
+      pageCounsels,
     };
 
     if (parseInt(page) === 1) {
@@ -105,7 +105,7 @@ exports.getReservedCounselList = async (req, res, next) => {
     }
 
     const reservedTotalCounsels = await Counsel.find(options).countDocuments();
-    const reservedCounsels = await Counsel.find(options)
+    const pageCounsels = await Counsel.find(options)
       .sort(sortBy)
       .limit(parseInt(limit))
       .skip((page - 1) * parseInt(limit))
@@ -115,7 +115,7 @@ exports.getReservedCounselList = async (req, res, next) => {
     const data = {
       hasPrevPage: true,
       hasNextPage: true,
-      reservedCounsels,
+      pageCounsels,
     };
 
     if (parseInt(page) === 1) {

--- a/controllers/counsels.controller.js
+++ b/controllers/counsels.controller.js
@@ -163,11 +163,6 @@ exports.updateCounsel = async (req, res, next) => {
     const { counsel_id } = req.params;
     const { counselor, startDate, endDate } = req.body;
 
-    if (!mongoose.isValidObjectId(counselor)) {
-      next(createError(400, MESSAGE.INVALID_OBJECT_ID));
-      return;
-    }
-
     const { counselors } = await Counsel.findById(counsel_id)
       .select("counselors")
       .lean();
@@ -213,11 +208,6 @@ exports.updateCounselors = async (req, res, next) => {
   try {
     const { counsel_id } = req.params;
     const { userId } = req.body;
-
-    if (!mongoose.isValidObjectId(userId)) {
-      next(createError(400, MESSAGE.INVALID_OBJECT_ID));
-      return;
-    }
 
     const { counselors } = await Counsel.findById(counsel_id)
       .select("counselors")

--- a/controllers/users.controller.js
+++ b/controllers/users.controller.js
@@ -1,4 +1,3 @@
-const mongoose = require("mongoose");
 const createError = require("http-errors");
 
 const User = require("../models/User");
@@ -72,27 +71,26 @@ exports.updateCounselorSchedule = async (req, res, next) => {
     const { user_id } = req.params;
     const { type, day, startHour, endHour, startDate, endDate } = req.body;
 
-    if (!mongoose.isValidObjectId(user_id)) {
-      next(createError(400, MESSAGE.INVALID_OBJECT_ID));
-      return;
-    }
-
-    await User.findByIdAndUpdate(user_id, {
-      $push: {
-        "counselor.availableDates": {
-          type,
-          day,
-          startHour,
-          endHour,
-          startDate,
-          endDate,
+    const availableDates = await User.findByIdAndUpdate(
+      user_id,
+      {
+        $push: {
+          "counselor.availableDates": {
+            type,
+            day,
+            startHour,
+            endHour,
+            startDate,
+            endDate,
+          },
         },
       },
-    }).lean();
+      { new: true }
+    ).lean();
 
     res.status(201).json({
       result: RESPONSE.SUCCESS,
-      data: null,
+      data: availableDates,
     });
   } catch (err) {
     next(createError(err));

--- a/controllers/users.controller.js
+++ b/controllers/users.controller.js
@@ -1,3 +1,4 @@
+const mongoose = require("mongoose");
 const createError = require("http-errors");
 
 const User = require("../models/User");
@@ -60,6 +61,38 @@ exports.updateUser = async (req, res, next) => {
     res.status(201).json({
       result: RESPONSE.SUCCESS,
       data: counselor,
+    });
+  } catch (err) {
+    next(createError(err));
+  }
+};
+
+exports.updateCounselorSchedule = async (req, res, next) => {
+  try {
+    const { user_id } = req.params;
+    const { type, day, startHour, endHour, startDate, endDate } = req.body;
+
+    if (!mongoose.isValidObjectId(user_id)) {
+      next(createError(400, MESSAGE.INVALID_OBJECT_ID));
+      return;
+    }
+
+    await User.findByIdAndUpdate(user_id, {
+      $push: {
+        "counselor.availableDates": {
+          type,
+          day,
+          startHour,
+          endHour,
+          startDate,
+          endDate,
+        },
+      },
+    }).lean();
+
+    res.status(201).json({
+      result: RESPONSE.SUCCESS,
+      data: null,
     });
   } catch (err) {
     next(createError(err));

--- a/mockData/new_counsel_data.json
+++ b/mockData/new_counsel_data.json
@@ -1,11 +1,101 @@
-{
-  "counselee": "6201cb5daf452eda2c0c89b2",
-  "counselor": "6201468fd480bfaf26bcc73f",
-  "title": "바다로 간 장금이",
-  "content": "lets go ~!!!!!!",
-  "tag": ["fire", "fighting", "ha ha"],
-  "createdAt": "2021-01-23T19:30:00.000+00:00",
-  "counselors": ["6201468fd480bfaf26bcc73d", "6201468fd480bfaf26bcc73c"],
-  "startDate": "2021-02-11T19:30:00.000+00:00",
-  "endDate": "2021-02-11T20:00:00.000+00:00"
-}
+[
+  {
+      "counselee": "6206782fda3e664d1a5592d4",
+      "counselor": "6201468fd480bfaf26bcc73f",
+      "title": "바다로 간 장금이",
+      "content": "lets go ~!!!!!!",
+      "tag": ["fire", "fighting", "ha ha"],
+      "createdAt": "2021-01-23T19:30:00.000Z",
+      "counselors": ["6201468fd480bfaf26bcc73f", "6201468fd480bfaf26bcc73c"],
+      "startDate": "2021-01-23T19:30:00.000Z",
+      "endDate": "2021-01-23T19:30:00.000Z"
+  },
+  {
+      "counselee": "6206a7c4c9a343d021ab1675",
+      "counselor": "6206a7c4c9a343d021ab167a",
+      "title": "오늘 뭐 먹지",
+      "content": "뭘 먹을지 고민이 되네요...",
+      "tag": ["밥", "점심", "ha ha"],
+      "createdAt": "2021-01-23T19:30:00.000Z",
+      "counselors": ["6206a7c4c9a343d021ab167a", "6201468fd480bfaf26bcc73c"],
+      "startDate": "2021-01-23T19:30:00.000Z",
+      "endDate": "2021-01-23T19:30:00.000Z"
+  },
+  {
+      "counselee": "6206a7c4c9a343d021ab1676",
+      "counselor": "6201468fd480bfaf26bcc73f",
+      "title": "손을 잘 닦자",
+      "content": "뽀득뽀득하게 씻자ㅏㅏ아ㅏㅏ",
+      "tag": ["코로나", "향균", "청결"],
+      "createdAt": "2021-01-23T19:30:00.000Z",
+      "counselors": ["6201468fd480bfaf26bcc73f", "6201468fd480bfaf26bcc73c"],
+      "startDate": "2021-01-23T19:30:00.000Z",
+      "endDate": "2021-01-23T19:30:00.000Z"
+  },
+      {
+      "counselee": "6206a7c4c9a343d021ab1677",
+      "counselor": "6201468fd480bfaf26bcc73f",
+      "title": "충전기가 필요해요",
+      "content": "lets go ~!!!!!!",
+      "tag": ["맥북", "충전기", "이만볼트"],
+      "createdAt": "2021-01-23T19:30:00.000Z",
+      "counselors": ["6201468fd480bfaf26bcc73d", "6201468fd480bfaf26bcc73f"],
+      "startDate": "2021-01-23T19:30:00.000Z",
+      "endDate": "2021-01-23T19:30:00.000Z"
+  },
+  {
+      "counselee": "6206a7c4c9a343d021ab1678",
+      "counselor": "6206a7c4c9a343d021ab167f",
+      "title": "아이스티에 샷 추가",
+      "content": "lets go ~!!!!!!",
+      "tag": ["fire", "fighting", "ha ha"],
+      "createdAt": "2021-01-23T19:30:00.000Z",
+      "counselors": ["6201468fd480bfaf26bcc73d", "6206a7c4c9a343d021ab167f"],
+      "startDate": "2021-01-23T19:30:00.000Z",
+      "endDate": "2021-01-23T19:30:00.000Z"
+  },
+  {
+      "counselee": "6206a7c4c9a343d021ab1679",
+      "counselor": "6201468fd480bfaf26bcc73f",
+      "title": "바니바니 당근 당근",
+      "content": "lets go ~!!!!!!",
+      "tag": ["바니", "토끼", "당근"],
+      "createdAt": "2021-01-23T19:30:00.000Z",
+      "counselors": ["6201468fd480bfaf26bcc73f", "6201468fd480bfaf26bcc73c"],
+      "startDate": "2021-01-23T19:30:00.000Z",
+      "endDate": "2021-01-23T19:30:00.000Z"
+  },
+  {
+      "counselee": "6206a7c4c9a343d021ab167a",
+      "counselor": "6201468fd480bfaf26bcc73f",
+      "title": "울랄라",
+      "content": "lets go ~!!!!!!",
+      "tag": ["fire", "fighting", "ha ha"],
+      "createdAt": "2021-01-23T19:30:00.000Z",
+      "counselors": ["6201468fd480bfaf26bcc73f", "6201468fd480bfaf26bcc73c"],
+      "startDate": "2021-01-23T19:30:00.000Z",
+      "endDate": "2021-01-23T19:30:00.000Z"
+  },
+  {
+      "counselee": "6206a7c4c9a343d021ab167b",
+      "counselor": "6206a7c4c9a343d021ab167e",
+      "title": "사랑한다 말하고 벽을 넘어서",
+      "content": "lets go ~!!!!!!",
+      "tag": ["fire", "fighting", "ha ha"],
+      "createdAt": "2021-01-23T19:30:00.000Z",
+      "counselors": ["6206a7c4c9a343d021ab167e", "6201468fd480bfaf26bcc73c"],
+      "startDate": "2021-01-23T19:30:00.000Z",
+      "endDate": "2021-01-23T19:30:00.000Z"
+  },
+  {
+      "counselee": "6206a7c4c9a343d021ab167c",
+      "counselor": "6206a7c4c9a343d021ab167d",
+      "title": "고민있어요",
+      "content": "lets go ~!!!!!!",
+      "tag": ["딸", "엄마", "학교"],
+      "createdAt": "2021-01-23T19:30:00.000Z",
+      "counselors": ["6201468fd480bfaf26bcc73d", "6206a7c4c9a343d021ab167d"],
+      "startDate": "2021-01-23T19:30:00.000Z",
+      "endDate": "2021-01-23T19:30:00.000Z"
+  }
+]

--- a/mockData/user_data.json
+++ b/mockData/user_data.json
@@ -2,14 +2,31 @@
   {
     "email": "hi@gmail.com",
     "nickname": "헝그리맨",
-    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
+    "imageURL": "https://avatars.dicebear.com/api/croodles/sojung.svg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
       "shortInput": "안녕하세요 새로운 카운슬러입니다.",
       "longInput": "저는 효자효녀로서 활동하고 있는 카운슬러입니다.",
       "tag": ["치킨", "피자", "막걸리"],
-      "validDate": []
+      "availableDates": [
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        },
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        }
+      ]
     }
   },
   {
@@ -22,98 +39,234 @@
       "shortInput": "안녕하세요 새로운 카운슬러입니다.",
       "longInput": "저는 효자효녀로서 활동하고 있는 카운슬러입니다.",
       "tag": ["치킨", "피자", "막걸리"],
-      "validDate": []
+      "availableDates": [
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        },
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        }
+      ]
     }
   },
   {
     "email": "proudman@gmail.com",
     "nickname": "프라우드먼",
-    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
+    "imageURL": "https://avatars.dicebear.com/api/female/sojung.svg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
       "shortInput": "안녕하세요 새로운 카운슬러입니다.",
       "longInput": "저는 효자효녀로서 활동하고 있는 카운슬러입니다.",
       "tag": ["치킨", "피자", "막걸리"],
-      "validDate": []
+      "availableDates": [
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        },
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        }
+      ]
     }
   },
   {
     "email": "camo@gmail.com",
     "nickname": "cashmoney",
-    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
+    "imageURL": "https://avatars.dicebear.com/api/croodles/coding.svg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
       "shortInput": "안녕하세요 새로운 카운슬러입니다.",
       "longInput": "저는 효자효녀로서 활동하고 있는 카운슬러입니다.",
       "tag": ["치킨", "피자", "막걸리"],
-      "validDate": []
+      "availableDates": [
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        },
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        }
+      ]
     }
   },
   {
     "email": "cl@gmail.com",
     "nickname": "닥터페퍼",
-    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
+    "imageURL": "https://avatars.dicebear.com/api/croodles/coding.svg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
       "shortInput": "안녕하세요 새로운 카운슬러입니다.",
       "longInput": "저는 효자효녀로서 활동하고 있는 카운슬러입니다.",
       "tag": ["치킨", "피자", "막걸리"],
-      "validDate": []
+      "availableDates": [
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        },
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        }
+      ]
     }
   },
   {
     "email": "noze@gmail.com",
     "nickname": "노제",
-    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
+    "imageURL": "https://avatars.dicebear.com/api/croodles/noze.svg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
       "shortInput": "안녕하세요 새로운 카운슬러입니다.",
       "longInput": "저는 효자효녀로서 활동하고 있는 카운슬러입니다.",
       "tag": ["치킨", "피자", "막걸리"],
-      "validDate": []
+      "availableDates": [
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        },
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        }
+      ]
     }
   },
   {
     "email": "g-dragon@gmail.com",
     "nickname": "권지용",
-    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
+    "imageURL": "https://avatars.dicebear.com/api/croodles/g-dragon.svg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
       "shortInput": "안녕하세요 새로운 카운슬러입니다.",
       "longInput": "저는 효자효녀로서 활동하고 있는 카운슬러입니다.",
       "tag": ["치킨", "피자", "막걸리"],
-      "validDate": []
+      "availableDates": [
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        },
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        }
+      ]
     }
   },
   {
     "email": "ken@gmail.com",
     "nickname": "허켄",
-    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
+    "imageURL": "https://avatars.dicebear.com/api/croodles/kenhuh.svg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
       "shortInput": "안녕하세요 새로운 카운슬러입니다.",
       "longInput": "저는 효자효녀로서 활동하고 있는 카운슬러입니다.",
       "tag": ["치킨", "피자", "막걸리"],
-      "validDate": []
+      "availableDates": [
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        },
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        }
+      ]
     }
   },
   {
     "email": "merkyuri@gmail.com",
     "nickname": "머큐리규리",
-    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
+    "imageURL": "https://avatars.dicebear.com/api/croodles/react.svg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
       "shortInput": "안녕하세요 새로운 카운슬러입니다.",
       "longInput": "저는 효자효녀로서 활동하고 있는 카운슬러입니다.",
       "tag": ["치킨", "피자", "막걸리"],
-      "validDate": []
+      "availableDates": [
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        },
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        }
+      ]
     }
   },
   {
@@ -126,20 +279,54 @@
       "shortInput": "안녕하세요 새로운 카운슬러입니다.",
       "longInput": "저는 효자효녀로서 활동하고 있는 카운슬러입니다.",
       "tag": ["치킨", "피자", "막걸리"],
-      "validDate": []
+      "availableDates": [
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        },
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        }
+      ]
     }
   },
   {
     "email": "loco@gmail.com",
     "nickname": "로꼬",
-    "imageURL": "https://newsimg-hams.hankookilbo.com/2021/12/31/4413435b-023d-478c-8637-433979169e40.jpg",
+    "imageURL": "https://avatars.dicebear.com/api/croodles/locco.svg",
     "notification": "60",
     "counselor": {
       "familyTitle": "효자효녀",
       "shortInput": "안녕하세요 새로운 카운슬러입니다.",
       "longInput": "저는 효자효녀로서 활동하고 있는 카운슬러입니다.",
       "tag": ["치킨", "피자", "막걸리"],
-      "validDate": []
+      "availableDates": [
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        },
+        {
+          "type": "day",
+          "startDate": "2022-01-11T12:30:00.000+00:00",
+          "endDate": "2022-03-11T13:00:00.000+00:00",
+          "day": "3",
+          "startHour": "14",
+          "endHour": "23"
+        }
+      ]
     }
   }
 ]

--- a/models/User.js
+++ b/models/User.js
@@ -42,11 +42,11 @@ const UserSchema = new mongoose.Schema({
     ],
     availableDates: {
       type: { type: String },
-      day: Number,
-      startHour: Number,
-      endHour: Number,
-      startDate: Date,
-      endDate: Date,
+      day: { type: Number },
+      startHour: { type: Number },
+      endHour: { type: Number },
+      startDate: { type: Date },
+      endDate: { type: Date },
     },
   },
 });

--- a/models/User.js
+++ b/models/User.js
@@ -40,16 +40,14 @@ const UserSchema = new mongoose.Schema({
         index: true,
       },
     ],
-    availableDates: [
-      {
-        type: { type: String },
-        day: Number,
-        startHour: Number,
-        endHour: Number,
-        startTime: Date,
-        endTime: Date,
-      },
-    ],
+    availableDates: {
+      type: { type: String },
+      day: Number,
+      startHour: Number,
+      endHour: Number,
+      startDate: Date,
+      endDate: Date,
+    },
   },
 });
 

--- a/models/User.js
+++ b/models/User.js
@@ -40,7 +40,7 @@ const UserSchema = new mongoose.Schema({
         index: true,
       },
     ],
-    availableDate: [
+    availableDates: [
       {
         type: { type: String },
         day: Number,

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,10 +1,19 @@
 const express = require("express");
 const router = express.Router();
 
-const { getCounselor, updateUser } = require("../controllers/users.controller");
+const {
+  getCounselor,
+  updateUser,
+  updateCounselorSchedule,
+} = require("../controllers/users.controller");
 const { checkObjectId } = require("../middlewares/validateObjectId");
 
 router.get("/:user_id", checkObjectId, getCounselor);
 router.patch("/:user_id", checkObjectId, updateUser);
+router.post(
+  "/:user_id/counselor/availableDates",
+  checkObjectId,
+  updateCounselorSchedule
+);
 
 module.exports = router;


### PR DESCRIPTION
# [AW-120] [Backend] POST 카운슬러 스케줄 변경 요청

## 지라 칸반 링크
- [[Backend] POST 카운슬러 스케줄 변경 요청](https://merkyuri.atlassian.net/browse/AW-120?atlOrigin=eyJpIjoiODkzNzRhOTY2MjdhNGQzNmE1YmI0Mzg5NmRhOGI1MTUiLCJwIjoiaiJ9)
  ​
## 카드에서 구현 혹은 해결하려는 내용
- ​마이페이지/카운슬러 페이지에서 유저가 가능한 시간대를 설정 할 수 있도록 한다.

## 테스트 방법
- postman) `/api/users/:user_id/counselor/availableDates` 경로에 다음과 같이 body에 담아 테스트
```json
{
    "type": "day",
    "day": "5",
    "startHour": "02",
    "endHour": "10",
    "startTime": "2023-01-11T12:30:00.000Z,
    "endTime": "2023-03-11T13:00:00.000Z
}
```
잘 담아서 보내진다.

## 기타 사항
- 리팩토링 시 참고: 기존의 데이터를 유저가 더 이상 원하지 않을 경우, 아예 매 설정시마다 리셋하고 새로 업데이트 할지 혹은 삭제 기능 추가. 


[AW-120]: https://merkyuri.atlassian.net/browse/AW-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ