### PR TITLE
[AW-130] 고민 담벼락 검색 버그 수정

### DIFF
--- a/controllers/counsels.controller.js
+++ b/controllers/counsels.controller.js
@@ -36,7 +36,7 @@ exports.getCounselList = async (req, res, next) => {
       ...(!!counselee && { counselee: { $eq: counselee } }),
     };
 
-    const totalCounsel = await Counsel.countDocuments();
+    const totalCounsels = await Counsel.find(options).countDocuments();
     const counsels = await Counsel.find(options)
       .sort(sortBy)
       .limit(parseInt(limit))
@@ -54,7 +54,7 @@ exports.getCounselList = async (req, res, next) => {
       storyList.hasPrevPage = false;
     }
 
-    if (parseInt(page) * limit >= totalCounsel) {
+    if (parseInt(page) * limit >= totalCounsels) {
       storyList.hasNextPage = false;
     }
 


### PR DESCRIPTION
## 지라 칸반 링크

- [[Backend] 고민 담벼락 검색 버그 수정](https://merkyuri.atlassian.net/browse/AW-130)
  ​

## 카드에서 구현 혹은 해결하려는 내용
- 카운슬러 countDocuments시 전체를 불러오는 것을 옵션에 맞게 수정

## 테스트 방법
- postman 혹은 고민 담벼락에서 해결

## 기타 사항
- NULL
